### PR TITLE
Config changes checking

### DIFF
--- a/cmd/edenClean.go
+++ b/cmd/edenClean.go
@@ -11,7 +11,10 @@ import (
 	"path/filepath"
 )
 
-var configDir string
+var (
+	configDir   string
+	configSaved string
+)
 
 var cleanCmd = &cobra.Command{
 	Use:   "clean",
@@ -31,6 +34,7 @@ var cleanCmd = &cobra.Command{
 			eserverImageDist = utils.ResolveAbsPath(viper.GetString("eden.images.dist"))
 			qemuFileToSave = utils.ResolveAbsPath(viper.GetString("eve.qemu-config"))
 			redisDist = utils.ResolveAbsPath(viper.GetString("redis.dist"))
+			configSaved = utils.ResolveAbsPath(defaults.DefaultConfigSaved)
 		}
 		return nil
 	},
@@ -39,8 +43,9 @@ var cleanCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("cannot obtain executable path: %s", err)
 		}
-		if err := utils.CleanEden(command, eveDist, adamDist, certsDir, eserverImageDist, redisDist,
-			configDir, evePidFile); err != nil {
+		if err := utils.CleanEden(command, eveDist, adamDist, certsDir,
+			eserverImageDist, redisDist, configDir, evePidFile,
+			configSaved); err != nil {
 			log.Fatalf("cannot CleanEden: %s", err)
 		}
 		log.Infof("CleanEden done")

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -22,6 +22,7 @@ const (
 	DefaultQemuFileToSave   = "qemu.conf"        //qemu config file inside DefaultEdenHomeDir
 	DefaultSSHKey           = "certs/id_rsa.pub" //file for save ssh key
 	DefaultConfigHidden     = ".eden-config.yml" //file to save config get --all
+	DefaultConfigSaved      = "config_saved.yml" //file to save config during 'eden setup'
 
 	DefaultContext = "default" //default context name
 

--- a/pkg/utils/eden.go
+++ b/pkg/utils/eden.go
@@ -442,7 +442,7 @@ func PrepareQEMUConfig(commandPath string, qemuConfigFile string, firmwareFile [
 }
 
 //CleanEden teardown Eden and cleanup
-func CleanEden(commandPath, eveDist, adamDist, certsDist, imagesDist, redisDist, configDir, evePID string) (err error) {
+func CleanEden(commandPath, eveDist, adamDist, certsDist, imagesDist, redisDist, configDir, evePID string, configSaved string) (err error) {
 	commandArgsString := fmt.Sprintf("stop --eve-pid=%s --adam-rm=true",
 		evePID)
 	log.Infof("CleanEden run: %s %s", commandPath, commandArgsString)
@@ -478,6 +478,11 @@ func CleanEden(commandPath, eveDist, adamDist, certsDist, imagesDist, redisDist,
 	if _, err = os.Stat(configDir); !os.IsNotExist(err) {
 		if err = os.RemoveAll(configDir); err != nil {
 			return fmt.Errorf("error in %s delete: %s", configDir, err)
+		}
+	}
+	if _, err = os.Stat(configSaved); !os.IsNotExist(err) {
+		if err = os.RemoveAll(configSaved); err != nil {
+			return fmt.Errorf("error in %s delete: %s", configSaved, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Checking for config changes during the 'eden setup'. Fix for https://github.com/lf-edge/eden/issues/83.

Testing procedure:
```
$ ./eden clean
INFO[0000] CleanEden run: /data/work/user/EVE/github/itmo-eve/eden/dist/bin/eden-linux-amd64 stop --eserver-pid=/home/user/work/EVE/github/itmo-eve/eden/dist/eserver.pid --eve-pid=/home/user/work/EVE/github/itmo-eve/eden/dist/eve.pid --adam-rm=true 
INFO[0000] CleanEden done                               
$ ./eden config add default
INFO[0000] Config file generated: /home/user/.eden/contexts/default.yml 
INFO[0000] QEMU config file generated: /home/user/.eden/qemu.conf
$ ./eden setup
INFO[0000] GenerateEveCerts run: /data/work/user/EVE/github/itmo-eve/eden/dist/bin/eden-linux-amd64 certs --certs-dist=/home/user/work/EVE/github/itmo-eve/eden/dist/certs --domain=mydomain.adam --ip=10.10.10.9 --eve-ip=10.10.10.9 --uuid=dbad51a8-9495-4ac9-ac72-259affd54db7 -v info 
INFO[0007] GenerateEveCerts done                        
INFO[0007] CopyCertsToAdamConfig done                   
INFO[0007] DownloadEveFormDocker run: /data/work/user/EVE/github/itmo-eve/eden/dist/bin/eden-linux-amd64 eve download --eve-tag=5.7.0 --eve-arch=amd64 --eve-hv=kvm --new-download=true -d /home/user/work/EVE/github/itmo-eve/eden/dist/eve/dist/amd64 -v info 
INFO[0000] Extract layer 9ec6d25d51993e0976c990c3630aab8cbddc3d073ea1751011bf8f120aa6b98c/layer.tar 
INFO[0043] download EVE done                            
$ ./eden config add rpi4 --devmodel RPi4
INFO[0000] Context file generated: /home/user/.eden/contexts/rpi4.yml 
$ ./eden config set rpi4
INFO[0000] Current context is: rpi4                
$ ./eden setup
FATA[0000] The current configuration file /home/user/.eden/contexts/rpi4.yml is different from the saved /home/user/work/EVE/github/itmo-eve/eden/dist/config_saved.yml. You can fix this with the commands 'eden config clean' and 'eden config add/set/edit'. 
$ ./eden config set default
INFO[0000] Current context is: default                  
$ ./eden setup
INFO[0000] Config file /home/user/.eden/contexts/default.yml is the same as /home/user/work/EVE/github/itmo-eve/eden/dist/config_saved.yml 
INFO[0000] Certs already exists in certs dir: /home/user/work/EVE/github/itmo-eve/eden/dist/certs 
INFO[0000] CopyCertsToAdamConfig done                   
INFO[0000] EVE already exists in dir: /home/user/work/EVE/github/itmo-eve/eden/dist/eve 
```