### PR TITLE
eserver, redis, adam volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ export ZARCH
 clean: config stop
 	make -C tests DEBUG=$(DEBUG) ARCH=$(ARCH) OS=$(OS) WORKDIR=$(WORKDIR) clean
 	$(LOCALBIN) clean
-	rm -rf $(LOCALBIN) $(BINDIR)/$(BIN) $(LOCALTESTBIN)
+	rm -rf $(LOCALBIN) $(BINDIR)/$(BIN) $(LOCALTESTBIN) $(WORKDIR)
 
 $(WORKDIR):
 	mkdir -p $@

--- a/cmd/adam.go
+++ b/cmd/adam.go
@@ -8,8 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"os"
-	"path"
-	"path/filepath"
 )
 
 var (
@@ -43,13 +41,6 @@ var startAdamCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		adamPath, err := filepath.Abs(adamDist)
-		if err != nil {
-			log.Fatalf("adam-dist problems: %s", err)
-		}
-		if _, err = os.Lstat(fmt.Sprintf("%s/run", adamPath)); os.IsNotExist(err) {
-			log.Fatalf("%s not found. Please run ./eden setup before start to generate certs", fmt.Sprintf("%s/run", adamPath))
-		}
 		command, err := os.Executable()
 		if err != nil {
 			log.Fatalf("cannot obtain executable path: %s", err)
@@ -58,7 +49,7 @@ var startAdamCmd = &cobra.Command{
 		if !adamRemoteRedis {
 			adamRemoteRedisURL = ""
 		}
-		if err := utils.StartAdam(adamPort, adamPath, adamForce, adamTag, adamRemoteRedisURL); err != nil {
+		if err := utils.StartAdam(adamPort, adamDist, adamForce, adamTag, adamRemoteRedisURL); err != nil {
 			log.Errorf("cannot start adam: %s", err)
 		} else {
 			log.Infof("Adam is running and accessible on port %d", adamPort)
@@ -116,12 +107,8 @@ func adamInit() {
 	adamCmd.AddCommand(startAdamCmd)
 	adamCmd.AddCommand(stopAdamCmd)
 	adamCmd.AddCommand(statusAdamCmd)
-	currentPath, err := os.Getwd()
-	if err != nil {
-		log.Fatal(err)
-	}
 	startAdamCmd.Flags().StringVarP(&adamTag, "adam-tag", "", defaults.DefaultAdamTag, "tag on adam container to pull")
-	startAdamCmd.Flags().StringVarP(&adamDist, "adam-dist", "", path.Join(currentPath, defaults.DefaultDist, defaults.DefaultAdamDist), "adam dist to start (required)")
+	startAdamCmd.Flags().StringVarP(&adamDist, "adam-dist", "", "", "adam dist to start (required)")
 	startAdamCmd.Flags().IntVarP(&adamPort, "adam-port", "", defaults.DefaultAdamPort, "adam port to start")
 	startAdamCmd.Flags().BoolVarP(&adamForce, "adam-force", "", false, "adam force rebuild")
 	startAdamCmd.Flags().StringVarP(&adamRemoteRedisURL, "adam-redis-url", "", "", "adam remote redis url")

--- a/cmd/downloader.go
+++ b/cmd/downloader.go
@@ -7,8 +7,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 )
@@ -87,16 +85,12 @@ var downloadEVERootFSCmd = &cobra.Command{
 }
 
 func downloaderInit() {
-	currentPath, err := os.Getwd()
-	if err != nil {
-		log.Fatal(err)
-	}
 	downloaderCmd.AddCommand(downloadEVECmd)
 	downloadEVECmd.Flags().StringVarP(&eveTag, "eve-tag", "", defaults.DefaultEVETag, "tag to download")
 	downloadEVECmd.Flags().StringVarP(&eveArch, "eve-arch", "", runtime.GOARCH, "arch of EVE")
 	downloadEVECmd.Flags().StringVarP(&eveHV, "eve-hv", "", defaults.DefaultEVEHV, "HV of EVE (kvm or xen)")
 	downloadEVECmd.Flags().StringVarP(&eveImageFile, "image-file", "i", "", "path for image drive")
-	downloadEVECmd.Flags().StringVarP(&adamDist, "adam-dist", "", path.Join(currentPath, defaults.DefaultDist, defaults.DefaultAdamDist), "adam dist to start")
+	downloadEVECmd.Flags().StringVarP(&adamDist, "adam-dist", "", "", "adam dist to start")
 	downloaderCmd.AddCommand(downloadEVERootFSCmd)
 	downloadEVERootFSCmd.Flags().StringVarP(&eveTag, "eve-tag", "", defaults.DefaultEVETag, "tag to download")
 	downloadEVERootFSCmd.Flags().StringVarP(&eveArch, "eve-arch", "", runtime.GOARCH, "arch of EVE")

--- a/cmd/edenClean.go
+++ b/cmd/edenClean.go
@@ -27,6 +27,7 @@ var cleanCmd = &cobra.Command{
 			return fmt.Errorf("error reading config: %s", err.Error())
 		}
 		if viperLoaded {
+			eveImageFile = utils.ResolveAbsPath(viper.GetString("eve.image-file"))
 			evePidFile = utils.ResolveAbsPath(viper.GetString("eve.pid"))
 			eveDist = utils.ResolveAbsPath(viper.GetString("eve.dist"))
 			adamDist = utils.ResolveAbsPath(viper.GetString("adam.dist"))
@@ -43,7 +44,7 @@ var cleanCmd = &cobra.Command{
 		if err != nil {
 			log.Fatalf("cannot obtain executable path: %s", err)
 		}
-		if err := utils.CleanEden(command, eveDist, adamDist, certsDir,
+		if err := utils.CleanEden(command, eveDist, adamDist, certsDir, filepath.Dir(eveImageFile),
 			eserverImageDist, redisDist, configDir, evePidFile,
 			configSaved); err != nil {
 			log.Fatalf("cannot CleanEden: %s", err)
@@ -63,10 +64,10 @@ func cleanInit() {
 	}
 	cleanCmd.Flags().StringVarP(&evePidFile, "eve-pid", "", filepath.Join(currentPath, defaults.DefaultDist, "eve.pid"), "file with EVE pid")
 	cleanCmd.Flags().StringVarP(&eveDist, "eve-dist", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultEVEDist), "directory to save EVE")
-	cleanCmd.Flags().StringVarP(&redisDist, "redis-dist", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultRedisDist), "redis dist")
+	cleanCmd.Flags().StringVarP(&redisDist, "redis-dist", "", "", "redis dist")
 	cleanCmd.Flags().StringVarP(&qemuFileToSave, "qemu-config", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultQemuFileToSave), "file to save qemu config")
-	cleanCmd.Flags().StringVarP(&adamDist, "adam-dist", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultAdamDist), "adam dist to start (required)")
-	cleanCmd.Flags().StringVarP(&eserverImageDist, "image-dist", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultImageDist), "image dist for eserver")
+	cleanCmd.Flags().StringVarP(&adamDist, "adam-dist", "", "", "adam dist to start (required)")
+	cleanCmd.Flags().StringVarP(&eserverImageDist, "image-dist", "", "", "image dist for eserver")
 
 	cleanCmd.Flags().StringVarP(&certsDir, "certs-dist", "o", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultCertsDist), "directory with certs")
 	cleanCmd.Flags().StringVarP(&configDir, "config-dist", "", configDist, "directory for config")

--- a/cmd/edenStart.go
+++ b/cmd/edenStart.go
@@ -64,22 +64,11 @@ var startCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		adamPath, err := filepath.Abs(adamDist)
-		if err != nil {
-			log.Fatalf("adam-dist problems: %s", err)
-		}
-		redisPath, err := filepath.Abs(redisDist)
-		if err != nil {
-			log.Fatalf("redis-dist problems: %s", err)
-		}
-		if err = os.MkdirAll(redisPath, 0755); err != nil {
-			log.Fatalf("Cannot create directory for redis (%s): %s", redisPath, err)
-		}
 		command, err := os.Executable()
 		if err != nil {
 			log.Fatalf("cannot obtain executable path: %s", err)
 		}
-		if err := utils.StartRedis(redisPort, redisPath, redisForce, redisTag); err != nil {
+		if err := utils.StartRedis(redisPort, redisDist, redisForce, redisTag); err != nil {
 			log.Errorf("cannot start redis: %s", err)
 		} else {
 			log.Infof("Redis is running and accessible on port %d", redisPort)
@@ -87,7 +76,7 @@ var startCmd = &cobra.Command{
 		if !adamRemoteRedis {
 			adamRemoteRedisURL = ""
 		}
-		if err := utils.StartAdam(adamPort, adamPath, adamForce, adamTag, adamRemoteRedisURL); err != nil {
+		if err := utils.StartAdam(adamPort, adamDist, adamForce, adamTag, adamRemoteRedisURL); err != nil {
 			log.Errorf("cannot start adam: %s", err)
 		} else {
 			log.Infof("Adam is running and accesible on port %d", adamPort)
@@ -114,16 +103,16 @@ func startInit() {
 		log.Fatal(err)
 	}
 	startCmd.Flags().StringVarP(&adamTag, "adam-tag", "", defaults.DefaultAdamTag, "tag on adam container to pull")
-	startCmd.Flags().StringVarP(&adamDist, "adam-dist", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultAdamDist), "adam dist to start (required)")
+	startCmd.Flags().StringVarP(&adamDist, "adam-dist", "", "", "adam dist to start (required)")
 	startCmd.Flags().IntVarP(&adamPort, "adam-port", "", defaults.DefaultAdamPort, "adam dist to start")
 	startCmd.Flags().BoolVarP(&adamForce, "adam-force", "", false, "adam force rebuild")
 	startCmd.Flags().StringVarP(&adamRemoteRedisURL, "adam-redis-url", "", "", "adam remote redis url")
 	startCmd.Flags().BoolVarP(&adamRemoteRedis, "adam-redis", "", true, "use adam remote redis")
 	startCmd.Flags().StringVarP(&redisTag, "redis-tag", "", defaults.DefaultRedisTag, "tag on redis container to pull")
-	startCmd.Flags().StringVarP(&redisDist, "redis-dist", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultRedisDist), "redis dist to start (required)")
+	startCmd.Flags().StringVarP(&redisDist, "redis-dist", "", "", "redis dist to start (required)")
 	startCmd.Flags().IntVarP(&redisPort, "redis-port", "", defaults.DefaultRedisPort, "redis dist to start")
 	startCmd.Flags().BoolVarP(&redisForce, "redis-force", "", false, "redis force rebuild")
-	startCmd.Flags().StringVarP(&eserverImageDist, "image-dist", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultImageDist), "image dist for eserver")
+	startCmd.Flags().StringVarP(&eserverImageDist, "image-dist", "", "", "image dist for eserver")
 	startCmd.Flags().IntVarP(&eserverPort, "eserver-port", "", defaults.DefaultEserverPort, "eserver port")
 	startCmd.Flags().StringVarP(&eserverTag, "eserver-tag", "", defaults.DefaultEServerTag, "tag of eserver container to pull")
 	startCmd.Flags().BoolVarP(&eserverForce, "eserver-force", "", false, "eserver force rebuild")

--- a/cmd/eserver.go
+++ b/cmd/eserver.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"os"
-	"path/filepath"
 )
 
 var eserverCmd = &cobra.Command{
@@ -39,11 +38,6 @@ var startEserverCmd = &cobra.Command{
 			log.Fatalf("cannot obtain executable path: %s", err)
 		}
 		log.Infof("Executable path: %s", command)
-
-		// lets make sure eserverImageDist exists
-		if os.MkdirAll(eserverImageDist, os.ModePerm) != nil {
-			log.Fatal("%s does not exist and can not be created", eserverImageDist)
-		}
 
 		if err := utils.StartEServer(eserverPort, eserverImageDist, eserverForce, eserverTag); err != nil {
 			log.Errorf("cannot start eserver: %s", err)
@@ -98,11 +92,7 @@ func eserverInit() {
 	eserverCmd.AddCommand(startEserverCmd)
 	eserverCmd.AddCommand(stopEserverCmd)
 	eserverCmd.AddCommand(statusEserverCmd)
-	currentPath, err := os.Getwd()
-	if err != nil {
-		log.Fatal(err)
-	}
-	startEserverCmd.Flags().StringVarP(&eserverImageDist, "image-dist", "", filepath.Join(currentPath, defaults.DefaultDist, defaults.DefaultImageDist), "image dist for eserver")
+	startEserverCmd.Flags().StringVarP(&eserverImageDist, "image-dist", "", "", "image dist for eserver")
 	startEserverCmd.Flags().IntVarP(&eserverPort, "eserver-port", "", defaults.DefaultEserverPort, "eserver port")
 	startEserverCmd.Flags().StringVarP(&eserverTag, "eserver-tag", "", defaults.DefaultEServerTag, "tag of eserver container to pull")
 	startEserverCmd.Flags().BoolVarP(&eserverForce, "eserver-force", "", false, "eserver force rebuild")

--- a/cmd/redis.go
+++ b/cmd/redis.go
@@ -8,8 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"os"
-	"path"
-	"path/filepath"
 )
 
 var (
@@ -43,19 +41,12 @@ var startRedisCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		redisPath, err := filepath.Abs(redisDist)
-		if err != nil {
-			log.Fatalf("redis-dist problems: %s", err)
-		}
-		if err = os.MkdirAll(redisPath, 0755); err != nil {
-			log.Fatalf("Cannot create directory for redis (%s): %s", redisPath, err)
-		}
 		command, err := os.Executable()
 		if err != nil {
 			log.Fatalf("cannot obtain executable path: %s", err)
 		}
 		log.Infof("Executable path: %s", command)
-		if err := utils.StartRedis(redisPort, redisPath, redisForce, redisTag); err != nil {
+		if err := utils.StartRedis(redisPort, redisDist, redisForce, redisTag); err != nil {
 			log.Errorf("cannot start redis: %s", err)
 		} else {
 			log.Infof("Redis is running and accessible on port %d", redisPort)
@@ -113,12 +104,8 @@ func redisInit() {
 	redisCmd.AddCommand(startRedisCmd)
 	redisCmd.AddCommand(stopRedisCmd)
 	redisCmd.AddCommand(statusRedisCmd)
-	currentPath, err := os.Getwd()
-	if err != nil {
-		log.Fatal(err)
-	}
 	startRedisCmd.Flags().StringVarP(&redisTag, "redis-tag", "", defaults.DefaultRedisTag, "tag of redis container to pull")
-	startRedisCmd.Flags().StringVarP(&redisDist, "redis-dist", "", path.Join(currentPath, defaults.DefaultDist, defaults.DefaultRedisDist), "redis dist to start (required)")
+	startRedisCmd.Flags().StringVarP(&redisDist, "redis-dist", "", "", "redis dist to start (required)")
 	startRedisCmd.Flags().IntVarP(&redisPort, "redis-port", "", defaults.DefaultRedisPort, "redis port to start")
 	startRedisCmd.Flags().BoolVarP(&redisForce, "redis-force", "", false, "redis force rebuild")
 	stopRedisCmd.Flags().BoolVarP(&redisRm, "redis-rm", "", false, "redis rm on stop")

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -10,8 +10,9 @@ const (
 	//directories and files
 	DefaultDist             = "dist"             //root directory
 	DefaultImageDist        = "images"           //directory for images inside dist
-	DefaultRedisDist        = "redis"            //directory for volume of redis inside dist
-	DefaultAdamDist         = "adam"             //directory for volume of adam inside dist
+	DefaultEserverDist      = ""                 //directory to mount eserver images
+	DefaultRedisDist        = ""                 //directory for volume of redis inside dist
+	DefaultAdamDist         = ""                 //directory for volume of adam inside dist
 	DefaultEVEDist          = "eve"              //directory for build EVE inside dist
 	DefaultCertsDist        = "certs"            //directory for certs inside dist
 	DefaultBinDist          = "bin"              //directory for binaries inside dist
@@ -40,7 +41,7 @@ const (
 
 	//tags, versions, repos
 	DefaultEVETag            = "5.7.1" //DefaultEVETag tag for EVE image
-	DefaultAdamTag           = "0.0.48"
+	DefaultAdamTag           = "0.0.51"
 	DefaultRedisTag          = "6"
 	DefaultLinuxKitVersion   = "v0.7"
 	DefaultImage             = "library/alpine"

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -103,7 +103,7 @@ adam:
     tag: {{ .DefaultAdamTag }}
 
     #location of adam
-    dist: {{ .DefaultAdamDist }}
+    dist: "{{ .DefaultAdamDist }}"
 
     #port of adam
     port: {{ .DefaultAdamPort }}
@@ -127,7 +127,7 @@ adam:
     force: true
 
     #certificate for communication with adam
-    ca: {{ .DefaultAdamDist }}/run/config/root-certificate.pem
+    ca: {{ .DefaultCertsDist }}/root-certificate.pem
 
     #use remote adam
     remote: 
@@ -171,7 +171,7 @@ eve:
     serial: "{{ .DefaultEVESerial }}"
 
     #onboarding certificate of EVE to put into adam
-    cert: certs/onboard.cert.pem
+    cert: {{ .DefaultCertsDist }}/onboard.cert.pem
 
     #EVE pid file
     pid: eve.pid
@@ -212,7 +212,7 @@ eve:
     dtb-part: ""
 
     #config part of EVE
-    config-part: {{ .DefaultAdamDist }}/run/config
+    config-part: {{ .DefaultCertsDist }}
 
     #is EVE remote or local
     remote: {{ .DefaultEVERemote }}
@@ -225,7 +225,7 @@ eden:
     root: {{ .Root }}
     images:
         #directory to save images
-        dist: {{ .DefaultImageDist }}
+        dist: "{{ .DefaultEserverDist }}"
 
     #download eve instead of build
     download: true
@@ -276,7 +276,7 @@ redis:
     tag: {{ .DefaultRedisTag }}
 
     #directory to use for redis persistence
-    dist: {{ .DefaultRedisDist }}
+    dist: "{{ .DefaultRedisDist }}"
 `
 
 //DefaultEdenDir returns path to default directory
@@ -415,7 +415,7 @@ func generateConfigFileFromTemplate(filePath string, templateString string) erro
 			DefaultAdamTag       string
 			DefaultAdamPort      int
 			DefaultImageDist     string
-			ImageDir             string
+			DefaultEserverDist   string
 			Root                 string
 			IP                   string
 			EVEIP                string
@@ -456,7 +456,7 @@ func generateConfigFileFromTemplate(filePath string, templateString string) erro
 			DefaultAdamPort:     defaults.DefaultAdamPort,
 			DefaultAdamTag:      defaults.DefaultAdamTag,
 			DefaultImageDist:    defaults.DefaultImageDist,
-			ImageDir:            filepath.Join(currentPath, defaults.DefaultImageDist),
+			DefaultEserverDist:  defaults.DefaultEserverDist,
 			Root:                filepath.Join(currentPath, defaults.DefaultDist),
 			IP:                  ip,
 			EVEIP:               eveIP,

--- a/pkg/utils/configDiff.go
+++ b/pkg/utils/configDiff.go
@@ -18,7 +18,7 @@ adam:
     ip: {{ .IP }}
 
     #certificate for communication with adam
-    ca: {{ .DefaultAdamDist }}/run/config/root-certificate.pem
+    ca: {{ .DefaultCertsDist }}/root-certificate.pem
 
     redis:
       #host of adam's redis for EDEN access
@@ -52,7 +52,7 @@ eve:
     serial: "{{ .DefaultEVESerial }}"
 
     #onboarding certificate of EVE to put into adam
-    cert: certs/onboard.cert.pem
+    cert: {{ .DefaultCertsDist }}/onboard.cert.pem
 
     #EVE firmware
     firmware: [{{ .DefaultImageDist }}/eve/OVMF_CODE.fd,{{ .DefaultImageDist }}/eve/OVMF_VARS.fd]

--- a/pkg/utils/dowloaders.go
+++ b/pkg/utils/dowloaders.go
@@ -11,16 +11,14 @@ import (
 )
 
 //DownloadEveLive pulls EVE live image from docker
-func DownloadEveLive(adamDist string, outputFile string, eveArch string, eveHV string, eveTag string, format string) (err error) {
+func DownloadEveLive(configPath string, outputFile string, eveArch string, eveHV string, eveTag string, format string) (err error) {
 	efiImage := fmt.Sprintf("lfedge/eve-uefi:%s-%s", eveTag, eveArch) //download OVMF
 	image := fmt.Sprintf("lfedge/eve:%s-%s-%s", eveTag, eveHV, eveArch)
 	log.Debugf("Try ImagePull with (%s)", image)
 	if err := PullImage(image); err != nil {
 		return fmt.Errorf("ImagePull (%s): %s", image, err)
 	}
-	var configPath string
-	if adamDist != "" {
-		configPath = filepath.Join(adamDist, "run", "config")
+	if configPath != "" {
 		if _, err := os.Stat(configPath); os.IsNotExist(err) {
 			return fmt.Errorf("directory not exists: %s", configPath)
 		}


### PR DESCRIPTION
The transition from mounting directories for service containers to using named volumes has been made. This transition will allow using remote docker instances.

Fixed interaction with Adam container. In the new implementation, the container is launched with the setting of the automatic certificate generation parameters (CN and hosts). Once generated, the public certificate is retrieved from Adam by an insecure request and added to the EVE configuration.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>