### PR TITLE
pod deploy parameters

### DIFF
--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -193,8 +193,8 @@ eve:
     #forward of ports in qemu [(HOST:EVE)]
     hostfwd:
         {{ .DefaultSSHPort }}: 22
-        5912: 5901
-        5911: 5900
+        5912: 5902
+        5911: 5901
         8027: 8027
         8028: 8028
 

--- a/pkg/utils/configDiff.go
+++ b/pkg/utils/configDiff.go
@@ -60,8 +60,8 @@ eve:
     #forward of ports in qemu [(HOST:EVE)]
     hostfwd:
         {{ .DefaultSSHPort }}: 22
-        5912: 5901
-        5911: 5900
+        5912: 5902
+        5911: 5901
         8027: 8027
         8028: 8028
 

--- a/tests/vnc/vnc_test.go
+++ b/tests/vnc/vnc_test.go
@@ -65,7 +65,7 @@ func getVNCPort(edgeNode *device.Ctx, vncDisplay int) int {
 	if edgeNode.GetDevModel() == defaults.DefaultRPIModel {
 		return 5900 + vncDisplay
 	} else {
-		return 5911 + vncDisplay //forwarded by qemu ports
+		return 5910 + vncDisplay //forwarded by qemu ports
 	}
 }
 


### PR DESCRIPTION
Flags added to pod deploy
      --cpus uint32           cpu number for app (default 1)
      --disk-size string      disk size (empty or 0 - same as in image) (default "0 B")
      --memory string         memory for app (default "1.0 GB")
      --vnc-display uint32    display number for VNC pod (0 - no VNC)
      --vnc-password string   VNC password (empty - no password)

Fixes for qemu port translation for VNC
