### PR TITLE
nohyper test flag for docker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/go-containerregistry v0.0.0-20200331213917-3d03ed9b1ca2
 	github.com/lf-edge/adam v0.0.0-20200502191324-bedd2e5e0d61
 	github.com/lf-edge/eden/eserver v0.0.0-00010101000000-000000000000
-	github.com/lf-edge/eve/api/go v0.0.0-20200711013237-83b38f65d2e4
+	github.com/lf-edge/eve/api/go v0.0.0-20200728121256-42a37934d692
 	github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40 // indirect
 	github.com/mcuadros/go-lookup v0.0.0-20200513230334-5988786b5617
 	github.com/nerd2/gexto v0.0.0-20190529073929-39468ec063f6

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,8 @@ github.com/lf-edge/eve/api/go v0.0.0-20200708222443-cb16dc711160 h1:n6YseL7R20AL
 github.com/lf-edge/eve/api/go v0.0.0-20200708222443-cb16dc711160/go.mod h1:DuAv0PyTTzmd3n25iHJ/Hx2SrbON4hf3I0oXfnUH4d8=
 github.com/lf-edge/eve/api/go v0.0.0-20200711013237-83b38f65d2e4 h1:jUWbxQbgZdm/zvRd3yaxYTALYXgb5l2bgOJGUIiReoE=
 github.com/lf-edge/eve/api/go v0.0.0-20200711013237-83b38f65d2e4/go.mod h1:DuAv0PyTTzmd3n25iHJ/Hx2SrbON4hf3I0oXfnUH4d8=
+github.com/lf-edge/eve/api/go v0.0.0-20200728121256-42a37934d692 h1:XVaGZOo4pw6uFbwajjI+6cbF/i2ss4pRS/k1/h9jq/Q=
+github.com/lf-edge/eve/api/go v0.0.0-20200728121256-42a37934d692/go.mod h1:DuAv0PyTTzmd3n25iHJ/Hx2SrbON4hf3I0oXfnUH4d8=
 github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40 h1:EnfXoSqDfSNJv0VBNqY/88RNnhSGYkrHaO0mmFGbVsc=
 github.com/lunixbochs/struc v0.0.0-20200707160740-784aaebc1d40/go.mod h1:vy1vK6wD6j7xX6O6hXe621WabdtNkou2h7uRtTfRMyg=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -40,7 +40,7 @@ const (
 	DefaultAdamPort    = 3333
 
 	//tags, versions, repos
-	DefaultEVETag            = "5.7.1" //DefaultEVETag tag for EVE image
+	DefaultEVETag            = "0.0.0-snapshot-master-3d7221dd" //DefaultEVETag tag for EVE image
 	DefaultAdamTag           = "0.0.51"
 	DefaultRedisTag          = "6"
 	DefaultLinuxKitVersion   = "v0.7"

--- a/pkg/expect/docker.go
+++ b/pkg/expect/docker.go
@@ -76,5 +76,6 @@ func (exp *appExpectation) createAppInstanceConfigDocker(img *config.Image, id u
 		Image:        img,
 		Maxsizebytes: maxSizeBytes,
 	}}
+	app.Fixedresources.VirtualizationMode = exp.virtualizationMode
 	return app
 }

--- a/pkg/expect/expectation.go
+++ b/pkg/expect/expectation.go
@@ -44,6 +44,8 @@ type appExpectation struct {
 	diskSize int64
 
 	uplinkAdapter *config.Adapter
+
+	virtualizationMode config.VmMode
 }
 
 //AppExpectationFromUrl init appExpectation with defined:
@@ -72,6 +74,14 @@ func AppExpectationFromUrl(ctrl controller.Cloud, appLink string, podName string
 		mem:     defaults.DefaultAppMem,
 
 		uplinkAdapter: adapter,
+	}
+	switch expectation.ctrl.GetVars().ZArch {
+	case "amd64":
+		expectation.virtualizationMode = config.VmMode_HVM
+	case "arm64":
+		expectation.virtualizationMode = config.VmMode_PV
+	default:
+		log.Fatalf("Unexpected arch %s", expectation.ctrl.GetVars().ZArch)
 	}
 	for _, opt := range opts {
 		opt(expectation)

--- a/pkg/expect/options.go
+++ b/pkg/expect/options.go
@@ -2,6 +2,7 @@ package expect
 
 import (
 	"github.com/lf-edge/eden/pkg/defaults"
+	"github.com/lf-edge/eve/api/go/config"
 	"strings"
 )
 
@@ -65,5 +66,12 @@ func WithResources(cpus uint32, memory uint32) ExpectationOption {
 	return func(expectation *appExpectation) {
 		expectation.cpu = cpus
 		expectation.mem = memory
+	}
+}
+
+//WithVirtualizationMode sets virtualizationMode for app
+func WithVirtualizationMode(virtualizationMode config.VmMode) ExpectationOption {
+	return func(expectation *appExpectation) {
+		expectation.virtualizationMode = virtualizationMode
 	}
 }

--- a/pkg/expect/vm.go
+++ b/pkg/expect/vm.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"github.com/lf-edge/eve/api/go/config"
 	uuid "github.com/satori/go.uuid"
-	"log"
 )
 
 //createAppInstanceConfigVM creates AppInstanceConfig for VM with provided img, netInstance, id and acls
@@ -25,16 +24,11 @@ func (exp *appExpectation) createAppInstanceConfigVM(img *config.Image, id uuid.
 		Activate:    true,
 		Displayname: exp.appName,
 	}
-	switch exp.ctrl.GetVars().ZArch {
-	case "amd64":
-		app.Fixedresources.VirtualizationMode = config.VmMode_HVM
-	case "arm64":
-		app.Fixedresources.VirtualizationMode = config.VmMode_PV
+	if exp.virtualizationMode == config.VmMode_PV {
 		app.Fixedresources.Rootdev = "/dev/xvda1"
 		app.Fixedresources.Bootloader = "/usr/bin/pygrub"
-	default:
-		log.Fatalf("Unexpected arch %s", exp.ctrl.GetVars().ZArch)
 	}
+	app.Fixedresources.VirtualizationMode = exp.virtualizationMode
 	maxSizeBytes := img.SizeBytes
 	if exp.diskSize > 0 {
 		maxSizeBytes = exp.diskSize


### PR DESCRIPTION
`./eden test tests/docker/ -v debug -a '-nohyper true'` starts testing docker without hypervisor.
`github.com/lf-edge/eve/api/go` and `DefaultEVETag` updated for nohyper support.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>