### PR TITLE
[WIP] volume-type in pod deploy

### DIFF
--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -36,6 +36,7 @@ var (
 	appMemory   string
 	diskSize    string
 	imageFormat string
+	volumeType  string
 
 	outputTail   uint
 	outputFields []string
@@ -92,6 +93,7 @@ var podDeployCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
+		opts = append(opts, expect.WithVolumeType(expect.VolumeTypeByName(volumeType)))
 		opts = append(opts, expect.WithResources(appCpus, uint32(appMemoryParsed/1000)))
 		opts = append(opts, expect.WithImageFormat(imageFormat))
 		expectation := expect.AppExpectationFromUrl(ctrl, dev, appLink, podName, opts...)
@@ -591,6 +593,7 @@ func podInit() {
 	podDeployCmd.Flags().Uint32Var(&appCpus, "cpus", defaults.DefaultAppCpu, "cpu number for app")
 	podDeployCmd.Flags().StringVar(&appMemory, "memory", humanize.Bytes(defaults.DefaultAppMem*1024), "memory for app")
 	podDeployCmd.Flags().StringVar(&diskSize, "disk-size", humanize.Bytes(0), "disk size (empty or 0 - same as in image)")
+	podDeployCmd.Flags().StringVar(&volumeType, "volume-type", "qcow2", "volume type for empty volumes (qcow2 or oci)")
 	podDeployCmd.Flags().StringSliceVar(&podNetworks, "networks", nil, "Networks to connect to app (ports will be mapped to first network)")
 	podDeployCmd.Flags().StringVar(&imageFormat, "format", "", "format for image, one of 'container','qcow2'; if not provided, defaults to container image for docker and oci transports, qcow2 for file and http/s transports")
 	podCmd.AddCommand(podPsCmd)

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -106,9 +106,8 @@ const (
 
 	DefaultVolumeSize = 1024 * 1024 * 200
 
-	//DefaultEmptyVolumeLink = "http://sdn.ifmo.ru/projects/eve/adam/disks/100m/at_download/file"
-	//DefaultEmptyVolumeLink = "docker://alpine"
-	DefaultEmptyVolumeLink = "empty.qcow2"
+	DefaultEmptyVolumeLinkDocker = "docker://hello-world"
+	DefaultEmptyVolumeLinkQcow2  = "empty.qcow2"
 )
 
 var (

--- a/pkg/expect/docker.go
+++ b/pkg/expect/docker.go
@@ -111,7 +111,10 @@ func obtainVolumeInfo(image *config.Image) ([]string, error) {
 
 //prepareImage generates new image for mountable volume
 func (exp *appExpectation) prepareImage() *config.Image {
-	appLink := defaults.DefaultEmptyVolumeLink
+	appLink := defaults.DefaultEmptyVolumeLinkQcow2
+	if exp.volumesType == VolumeOCI {
+		appLink = defaults.DefaultEmptyVolumeLinkDocker
+	}
 	if !strings.Contains(appLink, "://") {
 		//if we use file, we must resolve absolute path
 		appLink = fmt.Sprintf("file://%s", utils.ResolveAbsPath(appLink))

--- a/pkg/expect/expectation.go
+++ b/pkg/expect/expectation.go
@@ -51,6 +51,8 @@ type appExpectation struct {
 	virtualizationMode config.VmMode
 
 	device *device.Ctx
+
+	volumesType VolumeType
 }
 
 //AppExpectationFromUrl init appExpectation with defined:
@@ -81,6 +83,7 @@ func AppExpectationFromUrl(ctrl controller.Cloud, device *device.Ctx, appLink st
 
 		uplinkAdapter: adapter,
 		device:        device,
+		volumesType:   VolumeQcow2,
 	}
 	switch expectation.ctrl.GetVars().ZArch {
 	case "amd64":

--- a/pkg/expect/options.go
+++ b/pkg/expect/options.go
@@ -5,7 +5,30 @@ import (
 
 	"github.com/lf-edge/eden/pkg/defaults"
 	"github.com/lf-edge/eve/api/go/config"
+	log "github.com/sirupsen/logrus"
 )
+
+//VolumeType defines type of empty volumes to use
+type VolumeType string
+
+//VolumeQcow2 use empty qcow2 image for volumes
+var VolumeQcow2 VolumeType = "qcow2"
+
+//VolumeOCI use empty oci image for volumes
+var VolumeOCI VolumeType = "oci"
+
+//VolumeTypeByName returns VolumeType by name
+func VolumeTypeByName(name string) VolumeType {
+	switch name {
+	case "qcow2":
+		return VolumeQcow2
+	case "oci":
+		return VolumeOCI
+	default:
+		log.Fatalf("Not supported volume type %s", name)
+	}
+	return VolumeQcow2
+}
 
 //ExpectationOption is type to use for creation of appExpectation
 type ExpectationOption func(expectation *appExpectation)
@@ -93,5 +116,12 @@ func WithVirtualizationMode(virtualizationMode config.VmMode) ExpectationOption 
 func WithImageFormat(format string) ExpectationOption {
 	return func(expectation *appExpectation) {
 		expectation.imageFormat = format
+	}
+}
+
+//WithVolumeType sets empty volumes type for app
+func WithVolumeType(volumesType VolumeType) ExpectationOption {
+	return func(expectation *appExpectation) {
+		expectation.volumesType = volumesType
 	}
 }


### PR DESCRIPTION
`./eden pod deploy -p 8027:22 docker://itmoeve/volume-alpine:1.0 --vnc-display=1 --volume-type=oci -v debug`

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>