### PR TITLE
Fix config option for multiple contexts support

### DIFF
--- a/.github/workflows/eden_setup.yml
+++ b/.github/workflows/eden_setup.yml
@@ -39,9 +39,15 @@ jobs:
           make build-tests
       - name: run
         run: |
+          # check separate (non-default) config
           ./eden config add setup
+          ./eden config set setup --key=eve.accel --value=false
           ./eden --config setup setup
+          ./eden --config setup start
+          ./eden --config setup eve onboard
+          ./eden --config setup info
           ./eden --config setup clean
+          
           ./eden config add setup --arch=arm64
           ./eden --config setup setup
           ./eden --config setup clean

--- a/cmd/adam.go
+++ b/cmd/adam.go
@@ -10,20 +10,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newAdamCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newAdamCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var adamCmd = &cobra.Command{
 		Use:               "adam",
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 	}
 
 	groups := CommandGroups{
 		{
 			Message: "Basic Commands",
 			Commands: []*cobra.Command{
-				newStartAdamCmd(cfg),
-				newStopAdamCmd(),
-				newStatusAdamCmd(),
+				base.newStartAdamCmd(cfg),
+				base.newStopAdamCmd(),
+				base.newStatusAdamCmd(),
 			},
 		},
 	}
@@ -33,7 +33,7 @@ func newAdamCmd(configName, verbosity *string) *cobra.Command {
 	return adamCmd
 }
 
-func newStartAdamCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
+func (base baseCmd) newStartAdamCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 	var startAdamCmd = &cobra.Command{
 		Use:   "start",
 		Short: "start adam",
@@ -55,7 +55,7 @@ func newStartAdamCmd(cfg *openevec.EdenSetupArgs) *cobra.Command {
 	return startAdamCmd
 }
 
-func newStopAdamCmd() *cobra.Command {
+func (base baseCmd) newStopAdamCmd() *cobra.Command {
 	var adamRm bool
 
 	var stopAdamCmd = &cobra.Command{
@@ -74,7 +74,7 @@ func newStopAdamCmd() *cobra.Command {
 	return stopAdamCmd
 }
 
-func newStatusAdamCmd() *cobra.Command {
+func (base baseCmd) newStatusAdamCmd() *cobra.Command {
 	var statusAdamCmd = &cobra.Command{
 		Use:   "status",
 		Short: "status of adam",

--- a/cmd/disks.go
+++ b/cmd/disks.go
@@ -10,9 +10,11 @@ import (
 )
 
 func (base baseCmd) newDisksCmd() *cobra.Command {
+	cfg := &openevec.EdenSetupArgs{}
 	var disksCmd = &cobra.Command{
-		Use:   "disks",
-		Short: `Manage disks of edge-node`,
+		Use:               "disks",
+		Short:             `Manage disks of edge-node`,
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 	}
 
 	groups := CommandGroups{

--- a/cmd/disks.go
+++ b/cmd/disks.go
@@ -9,7 +9,7 @@ import (
 	"github.com/thediveo/enumflag"
 )
 
-func newDisksCmd() *cobra.Command {
+func (base baseCmd) newDisksCmd() *cobra.Command {
 	var disksCmd = &cobra.Command{
 		Use:   "disks",
 		Short: `Manage disks of edge-node`,

--- a/cmd/edenClean.go
+++ b/cmd/edenClean.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newCleanCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newCleanCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var configDist, vmName string
 	var currentContext bool
@@ -20,9 +20,9 @@ func newCleanCmd(configName, verbosity *string) *cobra.Command {
 		Use:               "clean",
 		Short:             "clean harness",
 		Long:              `Clean harness.`,
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.EdenClean(*cfg, *configName, configDist, vmName, currentContext); err != nil {
+			if err := openevec.EdenClean(*cfg, *base.configName, configDist, vmName, currentContext); err != nil {
 				log.Fatalf("Setup eden failed: %s", err)
 			}
 		},

--- a/cmd/edenConfig.go
+++ b/cmd/edenConfig.go
@@ -9,13 +9,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newConfigCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newConfigCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var configCmd = &cobra.Command{
 		Use:               "config",
 		Short:             "work with config",
 		Long:              `Work with config.`,
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 	}
 
 	groups := CommandGroups{

--- a/cmd/edenController.go
+++ b/cmd/edenController.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newControllerCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newControllerCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var controllerMode string
 
@@ -14,7 +14,7 @@ func newControllerCmd(configName, verbosity *string) *cobra.Command {
 		Use:               "controller",
 		Short:             "interact with controller",
 		Long:              `Interact with controller.`,
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 	}
 
 	var edgeNode = &cobra.Command{

--- a/cmd/edenNetwork.go
+++ b/cmd/edenNetwork.go
@@ -8,7 +8,7 @@ import (
 	"github.com/thediveo/enumflag"
 )
 
-func newNetworkCmd() *cobra.Command {
+func (base baseCmd) newNetworkCmd() *cobra.Command {
 	var networkCmd = &cobra.Command{
 		Use: "network",
 	}

--- a/cmd/edenNetwork.go
+++ b/cmd/edenNetwork.go
@@ -9,8 +9,10 @@ import (
 )
 
 func (base baseCmd) newNetworkCmd() *cobra.Command {
+	cfg := &openevec.EdenSetupArgs{}
 	var networkCmd = &cobra.Command{
-		Use: "network",
+		Use:               "network",
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 	}
 
 	groups := CommandGroups{

--- a/cmd/edenPacket.go
+++ b/cmd/edenPacket.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newPacketCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newPacketCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var packetProjectName string
 

--- a/cmd/edenPod.go
+++ b/cmd/edenPod.go
@@ -11,11 +11,11 @@ import (
 	"github.com/thediveo/enumflag"
 )
 
-func newPodCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newPodCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var podCmd = &cobra.Command{
 		Use:               "pod",
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 	}
 
 	groups := CommandGroups{

--- a/cmd/edenRol.go
+++ b/cmd/edenRol.go
@@ -8,12 +8,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newRolCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newRolCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var rolCmd = &cobra.Command{
 		Use:               "rol",
 		Short:             `Manage devices in Rack Of Labs`,
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 	}
 
 	rolCmd.AddCommand(newRolRentCmd(cfg))

--- a/cmd/edenSetup.go
+++ b/cmd/edenSetup.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newSetupCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newSetupCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var configDir, softSerial, zedControlURL, ipxeOverride string
 	var grubOptions []string
@@ -21,9 +21,9 @@ func newSetupCmd(configName, verbosity *string) *cobra.Command {
 		Use:               "setup",
 		Short:             "setup harness",
 		Long:              `Setup harness.`,
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 		Run: func(cmd *cobra.Command, args []string) {
-			if err := openevec.SetupEden(*configName, configDir, softSerial,
+			if err := openevec.SetupEden(*base.configName, configDir, softSerial,
 				zedControlURL, ipxeOverride, grubOptions, netboot, installer, *cfg); err != nil {
 
 				log.Fatalf("Setup eden failed: %s", err)

--- a/cmd/edenStart.go
+++ b/cmd/edenStart.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newStartCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newStartCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var zedControlURL, vmName, tapInterface string
 
@@ -19,7 +19,7 @@ func newStartCmd(configName, verbosity *string) *cobra.Command {
 		Use:               "start",
 		Short:             "start harness",
 		Long:              `Start harness.`,
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := openevec.StartEden(cfg, vmName, zedControlURL, tapInterface); err != nil {
 				log.Fatalf("Start eden failed: %s", err)

--- a/cmd/edenStatus.go
+++ b/cmd/edenStatus.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newStatusCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newStatusCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var allConfigs bool
 	var vmName string
@@ -19,7 +19,7 @@ func newStatusCmd(configName, verbosity *string) *cobra.Command {
 		Use:               "status",
 		Short:             "status of harness",
 		Long:              `Status of harness.`,
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := openevec.Status(cfg, vmName, allConfigs); err != nil {
 				log.Fatal(err)

--- a/cmd/edenStop.go
+++ b/cmd/edenStop.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newStopCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newStopCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var vmName string
 	var adamRm, registryRm, redisRm, eServerRm bool
@@ -20,7 +20,7 @@ func newStopCmd(configName, verbosity *string) *cobra.Command {
 		Use:               "stop",
 		Short:             "stop harness",
 		Long:              `Stop harness.`,
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 		Run: func(cmd *cobra.Command, args []string) {
 			eden.StopEden(
 				adamRm, redisRm,

--- a/cmd/edenTest.go
+++ b/cmd/edenTest.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newTestCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newTestCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var tstCfg openevec.TestArgs
 
@@ -27,7 +27,7 @@ test <test_dir> -r <regexp> [-t <timewait>] [-v <level>]
 
 `,
 		Args:              cobra.MaximumNArgs(1),
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			var err error
 			if len(args) != 0 {
@@ -63,7 +63,7 @@ test <test_dir> -r <regexp> [-t <timewait>] [-v <level>]
 				return fmt.Errorf("Please set the --scenario option or environment variable eden.test-scenario in the EDEN configuration.")
 			}
 			tstCfg.ConfigFile = cfg.ConfigFile
-			tstCfg.Verbosity = *verbosity
+			tstCfg.Verbosity = *base.verbosity
 			return nil
 		},
 		Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/edenUtils.go
+++ b/cmd/edenUtils.go
@@ -11,14 +11,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newUtilsCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newUtilsCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 
 	var utilsCmd = &cobra.Command{
 		Use:               "utils",
 		Short:             "Eden utilities",
 		Long:              `Additional utilities for EDEN.`,
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 	}
 
 	groups := CommandGroups{

--- a/cmd/edenVolume.go
+++ b/cmd/edenVolume.go
@@ -10,8 +10,10 @@ import (
 )
 
 func (base baseCmd) newVolumeCmd() *cobra.Command {
+	cfg := &openevec.EdenSetupArgs{}
 	var volumeCmd = &cobra.Command{
-		Use: "volume",
+		Use:               "volume",
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 	}
 
 	groups := CommandGroups{

--- a/cmd/edenVolume.go
+++ b/cmd/edenVolume.go
@@ -9,7 +9,7 @@ import (
 	"github.com/thediveo/enumflag"
 )
 
-func newVolumeCmd() *cobra.Command {
+func (base baseCmd) newVolumeCmd() *cobra.Command {
 	var volumeCmd = &cobra.Command{
 		Use: "volume",
 	}

--- a/cmd/eserver.go
+++ b/cmd/eserver.go
@@ -11,11 +11,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newEserverCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newEserverCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var eserverCmd = &cobra.Command{
 		Use:               "eserver",
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 	}
 
 	groups := CommandGroups{

--- a/cmd/eve.go
+++ b/cmd/eve.go
@@ -13,11 +13,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newEveCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newEveCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var eveCmd = &cobra.Command{
 		Use:               "eve",
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 	}
 	groups := CommandGroups{
 		{

--- a/cmd/flowlog.go
+++ b/cmd/flowlog.go
@@ -8,7 +8,7 @@ import (
 	"github.com/thediveo/enumflag"
 )
 
-func newNetStatCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newNetStatCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var outputFormat types.OutputFormat
 	var follow bool
@@ -20,7 +20,7 @@ func newNetStatCmd(configName, verbosity *string) *cobra.Command {
 		Short: "Get logs of network packets from a running EVE device",
 		Long: `Scans the ADAM flow messages for correspondence with regular expressions to show network flow statistics
 (TCP and UDP flows with IP addresses, port numbers, counters, whether dropped or accepted)`,
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := openevec.EdenNetStat(cfg, outputFormat, follow, logTail, printFields, args); err != nil {
 				log.Fatalf("Setup eden failed: %s", err)

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -9,15 +9,17 @@ import (
 )
 
 func (base baseCmd) newInfoCmd() *cobra.Command {
+	cfg := &openevec.EdenSetupArgs{}
 	var outputFormat types.OutputFormat
 	var infoTail uint
 	var follow bool
 	var printFields []string
 
 	var infoCmd = &cobra.Command{
-		Use:   "info [field:regexp ...]",
-		Short: "Get information reports from a running EVE device",
-		Long:  ` Scans the ADAM Info for correspondence with regular expressions requests to json fields.`,
+		Use:     "info [field:regexp ...]",
+		Short:   "Get information reports from a running EVE device",
+		Long:    ` Scans the ADAM Info for correspondence with regular expressions requests to json fields.`,
+		PreRunE: base.preRunViperLoadFunction(cfg),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := openevec.EdenInfo(outputFormat, infoTail, follow, printFields, args); err != nil {
 				log.Fatal("Eden info failed ", err)

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -8,7 +8,7 @@ import (
 	"github.com/thediveo/enumflag"
 )
 
-func newInfoCmd() *cobra.Command {
+func (base baseCmd) newInfoCmd() *cobra.Command {
 	var outputFormat types.OutputFormat
 	var infoTail uint
 	var follow bool

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -14,15 +14,17 @@ var outputFormatIds = map[types.OutputFormat][]string{
 }
 
 func (base baseCmd) newLogCmd() *cobra.Command {
+	cfg := &openevec.EdenSetupArgs{}
 	var outputFormat types.OutputFormat
 	var follow bool
 	var printFields []string
 	var logTail uint
 
 	var logCmd = &cobra.Command{
-		Use:   "log [field:regexp ...]",
-		Short: "Get logs from a running EVE device",
-		Long:  ` Scans the ADAM logs for correspondence with regular expressions requests to json fields.`,
+		Use:     "log [field:regexp ...]",
+		Short:   "Get logs from a running EVE device",
+		Long:    ` Scans the ADAM logs for correspondence with regular expressions requests to json fields.`,
+		PreRunE: base.preRunViperLoadFunction(cfg),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := openevec.EdenLog(outputFormat, follow, logTail, printFields, args); err != nil {
 				log.Fatalf("Log eden failed: %s", err)

--- a/cmd/log.go
+++ b/cmd/log.go
@@ -13,7 +13,7 @@ var outputFormatIds = map[types.OutputFormat][]string{
 	types.OutputFormatJSON:  {"json"},
 }
 
-func newLogCmd() *cobra.Command {
+func (base baseCmd) newLogCmd() *cobra.Command {
 	var outputFormat types.OutputFormat
 	var follow bool
 	var printFields []string

--- a/cmd/metric.go
+++ b/cmd/metric.go
@@ -8,7 +8,7 @@ import (
 	"github.com/thediveo/enumflag"
 )
 
-func newMetricCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newMetricCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var outputFormat types.OutputFormat
 	var follow bool
@@ -20,7 +20,7 @@ func newMetricCmd(configName, verbosity *string) *cobra.Command {
 		Short: "Get metrics from a running EVE device",
 		Long: `
 Scans the ADAM metrics for correspondence with regular expressions requests to json fields.`,
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := openevec.EdenMetric(cfg, outputFormat, follow, metricTail, printFields, args); err != nil {
 				log.Fatalf("Metric eden failed: %s", err)

--- a/cmd/redis.go
+++ b/cmd/redis.go
@@ -11,11 +11,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newRedisCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newRedisCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var redisCmd = &cobra.Command{
 		Use:               "redis",
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 	}
 
 	groups := CommandGroups{

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -10,11 +10,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newRegistryCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newRegistryCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var registryCmd = &cobra.Command{
 		Use:               "registry",
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 	}
 
 	groups := CommandGroups{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,40 +22,45 @@ func NewEdenCommand() *cobra.Command {
 		},
 	}
 
+	baseCmd := baseCmd{
+		configName: &configName,
+		verbosity:  &verbosity,
+	}
+
 	groups := CommandGroups{
 		{
 			Message: "Basic Commands",
 			Commands: []*cobra.Command{
-				newSetupCmd(&configName, &verbosity),
-				newStartCmd(&configName, &verbosity),
-				newEveCmd(&configName, &verbosity),
-				newPodCmd(&configName, &verbosity),
-				newStatusCmd(&configName, &verbosity),
-				newStopCmd(&configName, &verbosity),
-				newCleanCmd(&configName, &verbosity),
-				newConfigCmd(&configName, &verbosity),
-				newSdnCmd(&configName, &verbosity),
+				baseCmd.newSetupCmd(),
+				baseCmd.newStartCmd(),
+				baseCmd.newEveCmd(),
+				baseCmd.newPodCmd(),
+				baseCmd.newStatusCmd(),
+				baseCmd.newStopCmd(),
+				baseCmd.newCleanCmd(),
+				baseCmd.newConfigCmd(),
+				baseCmd.newSdnCmd(),
 			},
 		},
 		{
 			Message: "Advanced Commands",
 			Commands: []*cobra.Command{
-				newInfoCmd(),
-				newLogCmd(),
-				newNetStatCmd(&configName, &verbosity),
-				newMetricCmd(&configName, &verbosity),
-				newAdamCmd(&configName, &verbosity),
-				newRegistryCmd(&configName, &verbosity),
-				newRedisCmd(&configName, &verbosity),
-				newEserverCmd(&configName, &verbosity),
-				newTestCmd(&configName, &verbosity),
-				newUtilsCmd(&configName, &verbosity),
-				newControllerCmd(&configName, &verbosity),
-				newNetworkCmd(),
-				newVolumeCmd(),
-				newDisksCmd(),
-				newPacketCmd(&configName, &verbosity),
-				newRolCmd(&configName, &verbosity),
+				baseCmd.newInfoCmd(),
+				baseCmd.newLogCmd(),
+				baseCmd.newNetStatCmd(),
+				baseCmd.newMetricCmd(),
+				baseCmd.newAdamCmd(),
+				baseCmd.newRegistryCmd(),
+				baseCmd.newRedisCmd(),
+				baseCmd.newEserverCmd(),
+				baseCmd.newTestCmd(),
+				baseCmd.newUtilsCmd(),
+				baseCmd.newControllerCmd(),
+				baseCmd.newNetworkCmd(),
+				baseCmd.newVolumeCmd(),
+				baseCmd.newDisksCmd(),
+				baseCmd.newPacketCmd(),
+				baseCmd.newRolCmd(),
 			},
 		},
 	}
@@ -68,9 +73,14 @@ func NewEdenCommand() *cobra.Command {
 	return rootCmd
 }
 
-func preRunViperLoadFunction(cfg *openevec.EdenSetupArgs, configName, verbosity *string) func(cmd *cobra.Command, args []string) error {
+type baseCmd struct {
+	configName *string
+	verbosity  *string
+}
+
+func (base baseCmd) preRunViperLoadFunction(cfg *openevec.EdenSetupArgs) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		viperCfg, err := openevec.FromViper(*configName, *verbosity)
+		viperCfg, err := openevec.FromViper(*base.configName, *base.verbosity)
 		if err != nil {
 			return err
 		}

--- a/cmd/sdn.go
+++ b/cmd/sdn.go
@@ -16,12 +16,12 @@ var (
 	sdnFwdFromEp string
 )
 
-func newSdnCmd(configName, verbosity *string) *cobra.Command {
+func (base baseCmd) newSdnCmd() *cobra.Command {
 	cfg := &openevec.EdenSetupArgs{}
 	var sdnCmd = &cobra.Command{
 		Use:               "sdn",
 		Short:             "Emulate and manage networks surrounding EVE VM using Eden-SDN",
-		PersistentPreRunE: preRunViperLoadFunction(cfg, configName, verbosity),
+		PersistentPreRunE: base.preRunViperLoadFunction(cfg),
 	}
 
 	groups := CommandGroups{

--- a/pkg/openevec/config.go
+++ b/pkg/openevec/config.go
@@ -295,7 +295,8 @@ func LoadConfig(configFile string) (*EdenSetupArgs, error) {
 		configName = configName[:pos]
 	}
 
-	viper.SetConfigName(configName)
+	// we use viper.ConfigFileUsed() in utils.InitVars() to get current config file
+	viper.SetConfigFile(configFile)
 
 	return cfg, nil
 }


### PR DESCRIPTION
`--config` option does not work properly. We use `viper.ConfigFileUsed()` in `utils.InitVars()` to get current config file, so should use `viper.SetConfigFile()` instead of `viper.SetConfigName()`.